### PR TITLE
Add database

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.jetbrainsKotlinPluginParcelize)
+    alias(libs.plugins.kapt)
 }
 
 android {
@@ -49,6 +50,11 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.kotlin.stdlib)
+
+//    Database
+    implementation(libs.androidx.room.runtime)
+    kapt(libs.androidx.room.compiler)
+    implementation(libs.androidx.room.ktx)
 
 //    DI
     implementation (libs.koin.android)

--- a/app/src/main/java/com/example/playlist_maker/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/database/AppDatabase.kt
@@ -1,0 +1,9 @@
+package com.example.playlist_maker.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(version = 1, entities =[TrackDbEntity::class])
+abstract class AppDatabase: RoomDatabase() {
+    abstract fun trackDao(): TrackDao
+}

--- a/app/src/main/java/com/example/playlist_maker/data/database/TrackDao.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/database/TrackDao.kt
@@ -1,0 +1,24 @@
+package com.example.playlist_maker.data.database
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.playlist_maker.domain.prefs.dto.Track
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TrackDao {
+    @Insert(entity = TrackDbEntity::class, onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addTrack(track: TrackDbEntity)
+
+    @Delete(entity = TrackDbEntity::class)
+    fun deleteTrack(track: TrackDbEntity)
+
+    @Query("SELECT * FROM favourite_tracks_table")
+    fun getAllTracks(): Flow<List<TrackDbEntity>>
+
+    @Query("SELECT * FROM favourite_tracks_table WHERE trackId = :id")
+    fun findTrackInTable(id: String): List<Track>
+}

--- a/app/src/main/java/com/example/playlist_maker/data/database/TrackDatabaseMapper.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/database/TrackDatabaseMapper.kt
@@ -1,0 +1,33 @@
+package com.example.playlist_maker.data.database
+
+import com.example.playlist_maker.domain.prefs.dto.Track
+
+fun Track.toDatabase(): TrackDbEntity {
+    return TrackDbEntity(
+        trackId = this.trackId,
+        trackName = this.trackName,
+        artistName = this.artistName,
+        trackTimeMillis = this.trackTimeMillis,
+        collectionName = this.collectionName,
+        releaseDate = this.releaseDate,
+        primaryGenreName = this.primaryGenreName,
+        country = this.country,
+        artworkUrl100 = this.artworkUrl100,
+        previewUrl = this.previewUrl
+    )
+}
+
+fun TrackDbEntity.toDomain(): Track {
+    return Track(
+        trackId = this.trackId,
+        trackName = this.trackName,
+        artistName = this.artistName,
+        trackTimeMillis = this.trackTimeMillis,
+        collectionName = this.collectionName,
+        releaseDate = this.releaseDate,
+        primaryGenreName = this.primaryGenreName,
+        country = this.country,
+        artworkUrl100 = this.artworkUrl100,
+        previewUrl = this.previewUrl ?: ""
+    )
+}

--- a/app/src/main/java/com/example/playlist_maker/data/database/TrackDbEntity.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/database/TrackDbEntity.kt
@@ -1,0 +1,19 @@
+package com.example.playlist_maker.data.database
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favourite_tracks_table")
+data class TrackDbEntity(
+    @PrimaryKey
+    val trackId: String,
+    val trackName: String,
+    val artistName: String,
+    val trackTimeMillis: Int,
+    val collectionName: String?,
+    val releaseDate: String?,
+    val primaryGenreName: String,
+    val country: String,
+    val artworkUrl100: String?,
+    val previewUrl: String?
+)

--- a/app/src/main/java/com/example/playlist_maker/data/library/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/library/LibraryRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.playlist_maker.data.library
 
-import com.example.playlist_maker.data.database.AppDatabase
+import com.example.playlist_maker.data.database.TrackDao
 import com.example.playlist_maker.data.database.toDomain
 import com.example.playlist_maker.domain.library.repository_api.LibraryRepository
 import com.example.playlist_maker.domain.prefs.dto.Track
@@ -10,11 +10,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class LibraryRepositoryImpl(
-    private val db: AppDatabase
+    private val db: TrackDao
 ) : LibraryRepository {
     override suspend fun getTracksSubscribtion(): Flow<List<Track>> {
         return withContext(Dispatchers.IO) {
-            db.trackDao().getAllTracks().map {
+            db.getAllTracks().map {
                 it.map { track ->
                     track.toDomain()
                 }

--- a/app/src/main/java/com/example/playlist_maker/data/library/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/library/LibraryRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.example.playlist_maker.data.library
+
+import com.example.playlist_maker.data.database.AppDatabase
+import com.example.playlist_maker.data.database.toDomain
+import com.example.playlist_maker.domain.library.repository_api.LibraryRepository
+import com.example.playlist_maker.domain.prefs.dto.Track
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class LibraryRepositoryImpl(
+    private val db: AppDatabase
+) : LibraryRepository {
+    override suspend fun getTracksSubscribtion(): Flow<List<Track>> {
+        return withContext(Dispatchers.IO) {
+            db.trackDao().getAllTracks().map {
+                it.map { track ->
+                    track.toDomain()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/playlist_maker/data/player/repository/PlayerRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/player/repository/PlayerRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.playlist_maker.data.player.repository
 
-import com.example.playlist_maker.data.database.AppDatabase
+import com.example.playlist_maker.data.database.TrackDao
 import com.example.playlist_maker.data.database.toDatabase
 import com.example.playlist_maker.data.player.dto.toEntity
 import com.example.playlist_maker.data.player.service.PlayerService
@@ -12,7 +12,7 @@ import kotlinx.coroutines.withContext
 
 class PlayerRepositoryImpl(
     private val audioPlayerService: PlayerService,
-    private val database: AppDatabase
+    private val database: TrackDao
 ) : PlayerRepository {
     override fun preparePlayer(previewUrl: String) {
         audioPlayerService.preparePlayer(previewUrl)
@@ -28,20 +28,20 @@ class PlayerRepositoryImpl(
 
     override suspend fun addTrackToFavourite(track: Track) {
         withContext(Dispatchers.IO) {
-            database.trackDao().addTrack(track.toDatabase())
+            database.addTrack(track.toDatabase())
         }
     }
 
     override suspend fun deleteTrackFromFavourite(track: Track) {
         withContext(Dispatchers.IO) {
-            database.trackDao().deleteTrack(track.toDatabase())
+            database.deleteTrack(track.toDatabase())
         }
     }
 
     override suspend fun isTrackInFavourite(id: String): Boolean {
         var result = false
         withContext(Dispatchers.IO) {
-            val findTrackList = database.trackDao().findTrackInTable(id)
+            val findTrackList = database.findTrackInTable(id)
             if (findTrackList.isNotEmpty()) {
                 result = true
             }

--- a/app/src/main/java/com/example/playlist_maker/data/player/repository/PlayerRepositoryImpl.kt
+++ b/app/src/main/java/com/example/playlist_maker/data/player/repository/PlayerRepositoryImpl.kt
@@ -1,14 +1,20 @@
 package com.example.playlist_maker.data.player.repository
 
-import com.example.playlist_maker.data.player.service.PlayerService
+import com.example.playlist_maker.data.database.AppDatabase
+import com.example.playlist_maker.data.database.toDatabase
 import com.example.playlist_maker.data.player.dto.toEntity
+import com.example.playlist_maker.data.player.service.PlayerService
 import com.example.playlist_maker.domain.player.dto.PlayerState
 import com.example.playlist_maker.domain.player.repository_api.PlayerRepository
+import com.example.playlist_maker.domain.prefs.dto.Track
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class PlayerRepositoryImpl(
-    private val audioPlayerService: PlayerService
-): PlayerRepository {
-    override fun preparePlayer(previewUrl: String){
+    private val audioPlayerService: PlayerService,
+    private val database: AppDatabase
+) : PlayerRepository {
+    override fun preparePlayer(previewUrl: String) {
         audioPlayerService.preparePlayer(previewUrl)
     }
 
@@ -18,5 +24,28 @@ class PlayerRepositoryImpl(
 
     override fun isStatePrepared(): Boolean {
         return audioPlayerService.isStatePrepared()
+    }
+
+    override suspend fun addTrackToFavourite(track: Track) {
+        withContext(Dispatchers.IO) {
+            database.trackDao().addTrack(track.toDatabase())
+        }
+    }
+
+    override suspend fun deleteTrackFromFavourite(track: Track) {
+        withContext(Dispatchers.IO) {
+            database.trackDao().deleteTrack(track.toDatabase())
+        }
+    }
+
+    override suspend fun isTrackInFavourite(id: String): Boolean {
+        var result = false
+        withContext(Dispatchers.IO) {
+            val findTrackList = database.trackDao().findTrackInTable(id)
+            if (findTrackList.isNotEmpty()) {
+                result = true
+            }
+        }
+        return result
     }
 }

--- a/app/src/main/java/com/example/playlist_maker/di/DataModule.kt
+++ b/app/src/main/java/com/example/playlist_maker/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.example.playlist_maker.di
 import android.content.Context
 import androidx.room.Room
 import com.example.playlist_maker.data.database.AppDatabase
+import com.example.playlist_maker.data.database.TrackDao
 import com.example.playlist_maker.data.itunes_api.service.ITunesSearchAPI
 import com.example.playlist_maker.data.itunes_api.service.SearchService
 import com.example.playlist_maker.data.itunes_api.service.SearchServiceImpl
@@ -51,6 +52,11 @@ val dataModule = module {
             AppDatabase::class.java,
             "database.db"
         ).build()
+    }
+
+    single<TrackDao> {
+        val db: AppDatabase = get()
+        db.trackDao()
     }
 }
 

--- a/app/src/main/java/com/example/playlist_maker/di/DataModule.kt
+++ b/app/src/main/java/com/example/playlist_maker/di/DataModule.kt
@@ -1,6 +1,8 @@
 package com.example.playlist_maker.di
 
 import android.content.Context
+import androidx.room.Room
+import com.example.playlist_maker.data.database.AppDatabase
 import com.example.playlist_maker.data.itunes_api.service.ITunesSearchAPI
 import com.example.playlist_maker.data.itunes_api.service.SearchService
 import com.example.playlist_maker.data.itunes_api.service.SearchServiceImpl
@@ -41,6 +43,14 @@ val dataModule = module {
 
     single<SearchService> {
         SearchServiceImpl(get())
+    }
+
+    single<AppDatabase> {
+        Room.databaseBuilder(
+            androidContext(),
+            AppDatabase::class.java,
+            "database.db"
+        ).build()
     }
 }
 

--- a/app/src/main/java/com/example/playlist_maker/di/InteractorModule.kt
+++ b/app/src/main/java/com/example/playlist_maker/di/InteractorModule.kt
@@ -2,6 +2,8 @@ package com.example.playlist_maker.di
 
 import com.example.playlist_maker.domain.itunes_api.interactor.SearchUseCase
 import com.example.playlist_maker.domain.itunes_api.interactor.SearchUseCaseImpl
+import com.example.playlist_maker.domain.library.interactor.LibraryInteractor
+import com.example.playlist_maker.domain.library.interactor.LibraryInteractorImpl
 import com.example.playlist_maker.domain.player.interactor.PlayerInteractor
 import com.example.playlist_maker.domain.player.interactor.PlayerInteractorImpl
 import com.example.playlist_maker.domain.prefs.interactor.HistoryInteractor
@@ -11,6 +13,10 @@ import com.example.playlist_maker.domain.prefs.interactor.ThemeInteractorImpl
 import org.koin.dsl.module
 
 val interactorModule = module {
+    factory<LibraryInteractor> {
+        LibraryInteractorImpl(get())
+    }
+
     factory<PlayerInteractor> {
         PlayerInteractorImpl(get())
     }

--- a/app/src/main/java/com/example/playlist_maker/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/playlist_maker/di/RepositoryModule.kt
@@ -1,16 +1,22 @@
 package com.example.playlist_maker.di
 
 import com.example.playlist_maker.data.itunes_api.repository.SearchRepositoryImpl
+import com.example.playlist_maker.data.library.LibraryRepositoryImpl
 import com.example.playlist_maker.data.player.repository.PlayerRepositoryImpl
 import com.example.playlist_maker.data.prefs.repository.PrefsRepositoryImpl
 import com.example.playlist_maker.domain.itunes_api.repository_api.SearchRepository
+import com.example.playlist_maker.domain.library.repository_api.LibraryRepository
 import com.example.playlist_maker.domain.player.repository_api.PlayerRepository
 import com.example.playlist_maker.domain.prefs.repository_api.PrefsRepository
 import org.koin.dsl.module
 
 val repositoryModule = module {
+    factory<LibraryRepository> {
+        LibraryRepositoryImpl(get())
+    }
+
     factory<PlayerRepository> {
-        PlayerRepositoryImpl(get())
+        PlayerRepositoryImpl(get(), get())
     }
 
     factory<PrefsRepository> {

--- a/app/src/main/java/com/example/playlist_maker/di/ViewModelModule.kt
+++ b/app/src/main/java/com/example/playlist_maker/di/ViewModelModule.kt
@@ -16,7 +16,7 @@ val viewModelModule = module {
     }
 
     viewModel {
-        LibraryFavTracksPageViewModel()
+        LibraryFavTracksPageViewModel(get())
     }
 
     viewModel {

--- a/app/src/main/java/com/example/playlist_maker/domain/library/interactor/LibraryInteractor.kt
+++ b/app/src/main/java/com/example/playlist_maker/domain/library/interactor/LibraryInteractor.kt
@@ -1,0 +1,18 @@
+package com.example.playlist_maker.domain.library.interactor
+
+import com.example.playlist_maker.domain.library.repository_api.LibraryRepository
+import com.example.playlist_maker.domain.prefs.dto.Track
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+interface LibraryInteractor {
+    suspend fun getTracks(): Flow<List<Track>>
+}
+
+class LibraryInteractorImpl(
+    private val libraryRepository: LibraryRepository
+):LibraryInteractor {
+    override suspend fun getTracks(): Flow<List<Track>> {
+        return libraryRepository.getTracksSubscribtion().map { list -> list.reversed() }
+    }
+}

--- a/app/src/main/java/com/example/playlist_maker/domain/library/repository_api/LibraryRepository.kt
+++ b/app/src/main/java/com/example/playlist_maker/domain/library/repository_api/LibraryRepository.kt
@@ -1,0 +1,8 @@
+package com.example.playlist_maker.domain.library.repository_api
+
+import com.example.playlist_maker.domain.prefs.dto.Track
+import kotlinx.coroutines.flow.Flow
+
+interface LibraryRepository {
+    suspend fun getTracksSubscribtion(): Flow<List<Track>>
+}

--- a/app/src/main/java/com/example/playlist_maker/domain/player/interactor/PlayerInteractor.kt
+++ b/app/src/main/java/com/example/playlist_maker/domain/player/interactor/PlayerInteractor.kt
@@ -1,12 +1,16 @@
 package com.example.playlist_maker.domain.player.interactor
 
-import com.example.playlist_maker.domain.player.repository_api.PlayerRepository
 import com.example.playlist_maker.domain.player.dto.PlayerState
+import com.example.playlist_maker.domain.player.repository_api.PlayerRepository
+import com.example.playlist_maker.domain.prefs.dto.Track
 
 interface PlayerInteractor {
     fun preparePlayer(previewUrl: String)
     fun applyState(state: PlayerState)
     fun isStatePrepared(): Boolean
+    suspend fun addTrackToFavourite(track: Track)
+    suspend fun deleteTrackFromFavourite(track: Track)
+    suspend fun isTrackInFavourite(id: String): Boolean
 }
 
 class PlayerInteractorImpl(
@@ -22,5 +26,17 @@ class PlayerInteractorImpl(
 
     override fun isStatePrepared(): Boolean {
         return playerRepository.isStatePrepared()
+    }
+
+    override suspend fun addTrackToFavourite(track: Track) {
+        playerRepository.addTrackToFavourite(track)
+    }
+
+    override suspend fun deleteTrackFromFavourite(track: Track) {
+        playerRepository.deleteTrackFromFavourite(track)
+    }
+
+    override suspend fun isTrackInFavourite(id: String): Boolean {
+        return playerRepository.isTrackInFavourite(id)
     }
 }

--- a/app/src/main/java/com/example/playlist_maker/domain/player/repository_api/PlayerRepository.kt
+++ b/app/src/main/java/com/example/playlist_maker/domain/player/repository_api/PlayerRepository.kt
@@ -1,9 +1,13 @@
 package com.example.playlist_maker.domain.player.repository_api
 
 import com.example.playlist_maker.domain.player.dto.PlayerState
+import com.example.playlist_maker.domain.prefs.dto.Track
 
 interface PlayerRepository {
     fun preparePlayer(previewUrl: String)
     fun applyState(state: PlayerState)
     fun isStatePrepared(): Boolean
+    suspend fun addTrackToFavourite(track: Track)
+    suspend fun deleteTrackFromFavourite(track: Track)
+    suspend fun isTrackInFavourite(id: String): Boolean
 }

--- a/app/src/main/java/com/example/playlist_maker/presentation/library/dto/TrackLibraryItem.kt
+++ b/app/src/main/java/com/example/playlist_maker/presentation/library/dto/TrackLibraryItem.kt
@@ -1,0 +1,9 @@
+package com.example.playlist_maker.presentation.library.dto
+
+data class TrackLibraryItem(
+    val trackId: String,
+    val trackName: String,
+    val artistName: String,
+    val trackTime: String,
+    val artworkUrl100: String?,
+)

--- a/app/src/main/java/com/example/playlist_maker/presentation/library/dto/TrackUIMapper.kt
+++ b/app/src/main/java/com/example/playlist_maker/presentation/library/dto/TrackUIMapper.kt
@@ -1,0 +1,18 @@
+package com.example.playlist_maker.presentation.library.dto
+
+import com.example.playlist_maker.domain.prefs.dto.Track
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+fun Track.toLibraryUI(): TrackLibraryItem {
+    return TrackLibraryItem(
+        trackId = this.trackId,
+        trackName = this.trackName,
+        artistName = this.artistName,
+        trackTime = SimpleDateFormat(
+            "mm:ss",
+            Locale.getDefault()
+        ).format(this.trackTimeMillis),
+        artworkUrl100 = this.artworkUrl100
+    )
+}

--- a/app/src/main/java/com/example/playlist_maker/presentation/library/ui/LibraryFavTracksPageFragment.kt
+++ b/app/src/main/java/com/example/playlist_maker/presentation/library/ui/LibraryFavTracksPageFragment.kt
@@ -1,24 +1,93 @@
 package com.example.playlist_maker.presentation.library.ui
 
+import android.os.Bundle
+import android.view.View
+import androidx.core.os.bundleOf
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.playlist_maker.R
 import com.example.playlist_maker.databinding.FragmentLibraryFavTracksPageBinding
+import com.example.playlist_maker.domain.prefs.dto.Track
 import com.example.playlist_maker.presentation.common.BaseFragment
+import com.example.playlist_maker.presentation.library.dto.TrackLibraryItem
+import com.example.playlist_maker.presentation.library.ui.adapters.LibraryFavTracksAdapter
 import com.example.playlist_maker.presentation.library.view_model.LibraryFavTracksPageViewModel
+import com.example.playlist_maker.utils.debounce
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class LibraryFavTracksPageFragment : BaseFragment<FragmentLibraryFavTracksPageBinding>() {
-    private val viewModel by viewModel <LibraryFavTracksPageViewModel>()
+    private val viewModel by viewModel<LibraryFavTracksPageViewModel>()
+    private val libraryAdapter: LibraryFavTracksAdapter by lazy {
+        LibraryFavTracksAdapter(onItemClickListener = {
+            itemClickThrottler.invoke(it)
+        })
+    }
+    private lateinit var itemClickThrottler: (TrackLibraryItem) -> Unit
 
     override fun createViewBinding(): FragmentLibraryFavTracksPageBinding {
         return FragmentLibraryFavTracksPageBinding.inflate(layoutInflater)
     }
 
-    override fun initUi() {
-        with(viewBinding) {}
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        itemClickThrottler = debounce(
+            delay = CLICK_DELAY,
+            coroutineScope = viewLifecycleOwner.lifecycleScope,
+            isDebouncer = false
+        ) { item ->
+            viewModel.handleItemClick(item)
+        }
     }
 
-    override fun observeData() {}
+    override fun initUi() {
+        with(viewBinding) {
+            libraryFavTracksRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+            libraryFavTracksRecyclerView.adapter = libraryAdapter
+        }
+    }
+
+    override fun observeData() {
+        viewModel.currentState.observe(viewLifecycleOwner) {
+            applyState(it)
+        }
+
+        viewModel.navigationEvent.observe(viewLifecycleOwner) {
+            applyEvent(it)
+        }
+    }
+
+    private fun applyState(state: LibraryFavTracksPageViewModel.State) {
+        viewBinding.libraryFavTracksRecyclerView.isGone = true
+        viewBinding.noDataContainer.isGone = true
+
+        when (state) {
+            is LibraryFavTracksPageViewModel.State.NoData -> {
+                viewBinding.noDataContainer.isVisible = true
+            }
+
+            is LibraryFavTracksPageViewModel.State.Data -> {
+                viewBinding.libraryFavTracksRecyclerView.isVisible = true
+                libraryAdapter.setItems(state.list)
+            }
+        }
+    }
+
+    private fun applyEvent(track: Track) {
+        val bundle = bundleOf()
+        bundle.putSerializable(TRACK, track)
+
+        this@LibraryFavTracksPageFragment.findNavController()
+            .navigate(R.id.action_libraryFavTracksPageFragment_to_playerFragment, bundle)
+
+    }
 
     companion object {
         fun newInstance() = LibraryFavTracksPageFragment()
+        private const val CLICK_DELAY = 500L
+        private const val TRACK = "track"
     }
 }

--- a/app/src/main/java/com/example/playlist_maker/presentation/library/ui/adapters/LibraryFavTracksAdapter.kt
+++ b/app/src/main/java/com/example/playlist_maker/presentation/library/ui/adapters/LibraryFavTracksAdapter.kt
@@ -1,0 +1,65 @@
+package com.example.playlist_maker.presentation.library.ui.adapters
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.example.playlist_maker.R
+import com.example.playlist_maker.databinding.ItemTrackBinding
+import com.example.playlist_maker.presentation.library.dto.TrackLibraryItem
+import com.example.playlist_maker.utils.dpToPx
+
+class LibraryFavTracksAdapter(
+    private val onItemClickListener: (item: TrackLibraryItem) -> Unit
+) : RecyclerView.Adapter<LibraryFavTracksAdapter.ViewHolder>() {
+    private var items: List<TrackLibraryItem> = listOf()
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun setItems(list: List<TrackLibraryItem>) {
+        items = list
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder =
+        ViewHolder(
+            ItemTrackBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    inner class ViewHolder(private val binding: ItemTrackBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: TrackLibraryItem) {
+            with(binding) {
+                trackNameTextView.text = item.trackName
+                artistNameTextView.text = item.artistName
+                trackTimeTextView.text = item.trackTime
+                Glide.with(trackImageView)
+                    .load(item.artworkUrl100)
+                    .placeholder(R.drawable.placeholder_album)
+                    .fitCenter()
+                    .transform(RoundedCorners(dpToPx(2f, trackImageView.context)))
+                    .into(trackImageView)
+
+                artistNameTextView.invalidate()
+                artistNameTextView.requestLayout()
+
+                root.setOnClickListener {
+                    onItemClickListener.invoke(item)
+                }
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/example/playlist_maker/presentation/library/view_model/LibraryFavTracksPageViewModel.kt
+++ b/app/src/main/java/com/example/playlist_maker/presentation/library/view_model/LibraryFavTracksPageViewModel.kt
@@ -3,17 +3,51 @@ package com.example.playlist_maker.presentation.library.view_model
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.example.playlist_maker.presentation.search.dto.TrackItem
+import androidx.lifecycle.viewModelScope
+import com.example.playlist_maker.domain.library.interactor.LibraryInteractor
+import com.example.playlist_maker.domain.prefs.dto.Track
+import com.example.playlist_maker.presentation.library.dto.TrackLibraryItem
+import com.example.playlist_maker.presentation.library.dto.toLibraryUI
+import com.example.playlist_maker.utils.SingleLiveEvent
+import kotlinx.coroutines.launch
 
-class LibraryFavTracksPageViewModel : ViewModel() {
+class LibraryFavTracksPageViewModel(
+    private val libraryInteractor: LibraryInteractor
+) : ViewModel() {
+    private var tracksDomainList: List<Track> = listOf()
+
     private var _currentState: MutableLiveData<State> = MutableLiveData(State.NoData)
     val currentState: LiveData<State>
         get() = _currentState
 
+    private val _navigationEvent = SingleLiveEvent<Track>()
+    val navigationEvent: LiveData<Track>
+        get() = _navigationEvent
+
+    init {
+        viewModelScope.launch {
+            libraryInteractor.getTracks().collect {
+                tracksDomainList = it
+
+                if (tracksDomainList.isNotEmpty()) {
+                    _currentState.value = State.Data(tracksDomainList.map { it.toLibraryUI() })
+                } else {
+                    _currentState.value = State.NoData
+                }
+            }
+        }
+    }
+
+    fun handleItemClick(item: TrackLibraryItem) {
+        val track = tracksDomainList.firstOrNull { it.trackId == item.trackId }
+
+        if (track != null) {
+            _navigationEvent.value = track!!
+        }
+    }
 
     sealed class State {
-        class Data(val list: List<TrackItem>) : State()
+        class Data(val list: List<TrackLibraryItem>) : State()
         data object NoData : State()
-        data object Error : State()
     }
 }

--- a/app/src/main/res/navigation/library.xml
+++ b/app/src/main/res/navigation/library.xml
@@ -9,5 +9,17 @@
         android:id="@+id/libraryFragment"
         android:name="com.example.playlist_maker.presentation.library.ui.LibraryFragment"
         tools:layout="@layout/fragment_library">
+        <action
+            android:id="@+id/action_libraryFavTracksPageFragment_to_playerFragment"
+            app:destination="@id/playerFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/playerFragment"
+        android:name="com.example.playlist_maker.presentation.player.ui.PlayerFragment"
+        tools:layout="@layout/fragment_player">
+        <argument
+            android:name="track"
+            app:argType="com.example.playlist_maker.domain.prefs.dto.Track" />
     </fragment>
 </navigation>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.jetbrainsKotlinPluginParcelize) apply false
+    alias(libs.plugins.kapt) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,13 +14,18 @@ activity = "1.9.2"
 constraintlayout = "2.1.4"
 navigationFragmentKtx = "2.8.2"
 retrofit = "2.9.0"
+roomRuntime = "2.6.1"
 viewbinding = "8.7.0"
 kotlinStdlib = "2.0.0"
+kapt = "2.0.0"
 
 [libraries]
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationFragmentKtx" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "compiler" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
@@ -40,4 +45,5 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrainsKotlinPluginParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kapt" }
 


### PR DESCRIPTION
Критерий: В реализации репозитория, осуществляющего поиск треков, используется метод получения из БД списка идентификаторов треков, добавленных в избранное.

Так как в дизайне на экране поиска не предусмотрено никаких пометок рядом с уже добавленными в избранное треками, предлагаю другое решение данной задачи. Если при переходе на экран плеера делать запрос в БД о наличии трека по id, то операция будет куда легче, чем выгрузка всего списка id и прохождение по нему при клике на один из найденных треков. Также с данным решением не требуется изменять параметры при переходе с экрана поиск на экран плеера, чтобы передать актуальный флаг, отвечающий за «избранность» трека. И в этом решении не происходит «утечки» логики, необходимой только на экране плеера и медиатеки, на экран поиска. Единственный минус данного подхода – это поздняя загрузка статуса избранного для трека, однако задержка до появления актуального статуса минимальна.